### PR TITLE
bumping tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ name = "app"
 [dependencies]
 actix-rt = "1.1.1"
 actix-web = "3.1.0"
+tokio = { version = "0.3", features = ["rt"] }
 serde = { version = "1", features = ["derive"] }
 config = "0.10.1"
 uuid = { version = "0.8.1", features = ["v4"] }
@@ -40,5 +41,4 @@ features = [ "runtime-tokio", "macros", "postgres", "uuid", "chrono", "migrate",
 
 [dev-dependencies]
 reqwest = "0.10.8"
-tokio = "0.2.22"
 lazy_static = "1.4.0"


### PR DESCRIPTION
- from 0.2.22 (last of 0.2)
- to 0.3.x
- spawn was moved to feature flag, hence the "rt"

Too many changes for dependabot, reasonable